### PR TITLE
Fixed len count on multi-byte characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/momaek/formattag
+module github.com/seriallink/formattag
 
 go 1.18
 
-require github.com/fatih/structtag v1.2.0
+require (
+	github.com/fatih/structtag v1.2.0
+	golang.org/x/text v0.3.7
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/main.go
+++ b/main.go
@@ -11,8 +11,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/fatih/structtag"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 type config struct {
@@ -204,7 +208,7 @@ func (c *config) preProcessStruct(st *ast.StructType, inline ...bool) {
 		lens := make([]int, 0, tags.Len())
 		for _, key := range tags.Keys() {
 			t, _ := tags.Get(key)
-			lens = append(lens, len(t.String()))
+			lens = append(lens, length(t.String()))
 			ln.tags = append(ln.tags, t.String())
 		}
 
@@ -269,4 +273,10 @@ func updateResult(lines []*line, max, idx int) {
 			}
 		}
 	}
+}
+
+func length(s string) int {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	normalized, _, _ := transform.String(t, s)
+	return len(normalized)
 }


### PR DESCRIPTION
Before fix
```go
type Diacritics struct {
    A string `foo:"ä" json:"a"`
    E string `foo:"e"  json:"e"`
    I string `foo:"ï" json:"i"`
    O string `foo:"o"  json:"o"`
    U string `foo:"ü" json:"u"`
}
```

After fix 
```go
type Diacritics struct {
    A string `foo:"ä" json:"a"`
    E string `foo:"e" json:"e"`
    I string `foo:"ï" json:"i"`
    O string `foo:"o" json:"o"`
    U string `foo:"ü" json:"u"`
}
```